### PR TITLE
Add argument to generate more data per parameter

### DIFF
--- a/src/main/java/com/imperva/apiattacktool/cli/ApiAttackTool.java
+++ b/src/main/java/com/imperva/apiattacktool/cli/ApiAttackTool.java
@@ -30,6 +30,9 @@ public class ApiAttackTool implements Callable<Integer> {
     @Option(names = {"-ph", "--proxyHost"}, description = "Specify the proxy host to send the requests via a proxy")
     private String proxyHost;
 
+    @Option(names = {"-rpp", "--requestsPerParameter"}, description = "Specify the number of requests to send per the swagger's parameters (Strings excluded)")
+    private Integer numOfRequestsPerParameter;
+
     @Option(names = {"-pp", "--proxyPort"}, description = "The proxy port")
     private Integer proxyPort;
 
@@ -61,6 +64,10 @@ public class ApiAttackTool implements Callable<Integer> {
 
     public Integer getProxyPort() {
         return proxyPort;
+    }
+
+    public Integer getNumOfRequestsPerParameter() {
+        return numOfRequestsPerParameter;
     }
 
     public List<Integer> getUserProvidedPositiveResponseCodes() {

--- a/src/main/java/com/imperva/apiattacktool/tests/ScenariosDataProvider.java
+++ b/src/main/java/com/imperva/apiattacktool/tests/ScenariosDataProvider.java
@@ -54,7 +54,7 @@ public class ScenariosDataProvider {
     private static Object[][] getEndpointTestRequestData(TestDriver testDriver) {
         List<HttpRequestWrapper> httpRequestWrapperList;
         try {
-            httpRequestWrapperList = testDriver.getHttpRequestList(TestConfiguration.getSpecFilePath());
+            httpRequestWrapperList = testDriver.getHttpRequestList(TestConfiguration.getSpecFilePath(), TestConfiguration.getNumOfRequestsPerParameter());
         } catch (Exception anyException) {
             logger.error("Failed to get httpRequestList, for file: {}", TestConfiguration.getSpecFilePath(), anyException);
             return null;

--- a/src/main/java/com/imperva/apiattacktool/tests/TestConfiguration.java
+++ b/src/main/java/com/imperva/apiattacktool/tests/TestConfiguration.java
@@ -14,6 +14,7 @@ public class TestConfiguration {
 
     private static final int DEFAULT_PROXY_PORT = 80;
     private static final int DEFAULT_HOST_PORT = 443;
+    private static final int DEFAULT_NUM_OF_REQUESTS_PER_PARAMETER = 1;
 
     private static String specFilePath = System.getProperty("specFile", null);
 
@@ -27,6 +28,8 @@ public class TestConfiguration {
 
     private static Integer proxyPort = getIntegerFieldFromProperty("proxyPort", DEFAULT_PROXY_PORT);
 
+    private static Integer numOfRequestsPerParameter = getIntegerFieldFromProperty("numOfRequestsPerParameter", DEFAULT_NUM_OF_REQUESTS_PER_PARAMETER);
+
     private static Collection<Integer> userProvidedPositiveResponseCodes = getIntegerListFromProperty("addPositiveRC", Collections.emptyList());
 
     private static Collection<Integer> userProvidedNegativeResponseCodes = getIntegerListFromProperty("addNegativeRC", Collections.emptyList());
@@ -38,6 +41,7 @@ public class TestConfiguration {
         hostPort = apiAttackToolOptions.getHostPort();
         proxyHost = apiAttackToolOptions.getProxyHost();
         proxyPort = apiAttackToolOptions.getProxyPort();
+        numOfRequestsPerParameter = apiAttackToolOptions.getNumOfRequestsPerParameter();
         userProvidedPositiveResponseCodes =
             apiAttackToolOptions.getUserProvidedPositiveResponseCodes() == null
                 ? Collections.emptyList()
@@ -50,6 +54,10 @@ public class TestConfiguration {
 
     public static String getSpecFilePath() {
         return specFilePath;
+    }
+
+    public static int getNumOfRequestsPerParameter() {
+        return numOfRequestsPerParameter == null ? DEFAULT_NUM_OF_REQUESTS_PER_PARAMETER : numOfRequestsPerParameter;
     }
 
     public static String getHostScheme() {
@@ -86,8 +94,8 @@ public class TestConfiguration {
 
     public static String getWorkingConfigurationString() {
         return "API Spec file path: " + specFilePath + "\n"
-        + "Host: (" + hostScheme + ") " + hostName + " : " + getHostPort() + "\n"
-        + (isProxyDefined()
+            + "Host: (" + hostScheme + ") " + hostName + " : " + getHostPort() + "\n"
+            + (isProxyDefined()
             ? "Proxy Host: " + proxyHost + " : " + getProxyPort() + "\n"
             : "");
 

--- a/src/main/java/com/imperva/apiattacktool/tests/TestDriver.java
+++ b/src/main/java/com/imperva/apiattacktool/tests/TestDriver.java
@@ -5,5 +5,5 @@ import com.imperva.apiattacktool.model.tests.HttpRequestWrapper;
 import java.util.List;
 
 public interface TestDriver {
-    List<HttpRequestWrapper> getHttpRequestList(String resourceFileName);
+    List<HttpRequestWrapper> getHttpRequestList(String resourceFileName, int numOfRequestsPerParameter);
 }


### PR DESCRIPTION
- The parameter has a default value of 1 to maintain the tool's behaviour before this change.
- String parameters are excluded in the fuzzing process so the parameter is irrelevant for those parameters.